### PR TITLE
Correctly initialise data_field when GC'd

### DIFF
--- a/type-wrapper.hpp
+++ b/type-wrapper.hpp
@@ -58,7 +58,7 @@ namespace guile
   struct SCM_convertible<true>
   {
     SCM_convertible (SCM data):
-      data_field(scm_gc_protect_object(data_field))
+      data_field(scm_gc_protect_object(data))
     { }
 
     ~SCM_convertible()


### PR DESCRIPTION
This corrects a defect whereby the constructor of `SCM_convertible<GC_Protected>` attempts to GC protect the uninitialised contents of the field, rather than protecting the construction parameter.