### PR TITLE
Allow default construction when GC'd

### DIFF
--- a/type-wrapper.hpp
+++ b/type-wrapper.hpp
@@ -57,19 +57,27 @@ namespace guile
   template <>
   struct SCM_convertible<true>
   {
+    constexpr SCM_convertible () = default;
+  
     SCM_convertible (SCM data):
-      data_field(scm_gc_protect_object(data))
-    { }
+      data_field(data)
+    {
+      if (!scm_is_eq(data_field, SCM_UNDEFINED))
+        scm_gc_protect_object(data_field);
+    }
 
     ~SCM_convertible()
-    { scm_gc_unprotect_object(data_field); } 
+    {
+      if (!scm_is_eq(data_field, SCM_UNDEFINED))
+        scm_gc_unprotect_object(data_field);
+    } 
 
     
     /// implicite conversion to SCM.
     operator SCM()
     { return data_field; }
 
-    SCM data_field;
+    SCM data_field = SCM_UNDEFINED;
   };
   
   /** @brief The guile::wrap class, handle a important subset of guile


### PR DESCRIPTION
This addition makes it easier to use `SCM_convertible<GC_Protected>`
member variables in structure types that use default initialisation.

To facilitate this, this patch special-cases `SCM_UNDEFINED` as a
value that is never GC protected or unprotected.  For 
`SCM_UNDEFINED`, GC protection is not required because it is an
immediate value.  However, it must still be protected/unprotected in
pairs due to the internal implementation of `scm_gc_protect_object()`.